### PR TITLE
fix snooping dictionaries with DxfCode.Int32 type code

### DIFF
--- a/Snoop/CollectorExts/DbMisc.cs
+++ b/Snoop/CollectorExts/DbMisc.cs
@@ -466,7 +466,12 @@ namespace MgdDbg.Snoop.CollectorExts
                     dxfCodeStr = string.Format("{0:d}    (short)", typeCode);
                     data.Add(new Snoop.Data.Int(dxfCodeStr, (short)tmpVal.Value));
                 }
-                else if ((typeCode >= 90) && (typeCode <= 99)) {
+                else if (typeCode == 90)
+                {
+                    dxfCodeStr = string.Format("{0:d}    (int)", typeCode);
+                    data.Add(new Snoop.Data.Int(dxfCodeStr, (int)tmpVal.Value));
+                }
+                else if ((typeCode > 90) && (typeCode <= 99)) {
                     dxfCodeStr = string.Format("{0:d}    (long)", typeCode);
                     data.Add(new Snoop.Data.Int(dxfCodeStr, (int)(long)tmpVal.Value));
                 }


### PR DESCRIPTION
Hi! This pull request fixes reading int32 values from int fields of extension dictionaries:
![изображение](https://user-images.githubusercontent.com/14212214/149655754-1ee0107d-e0e8-4ebe-9c89-6cb3aa3802a6.png)

> System.InvalidCastException: Specified cast is not valid.
   at MgdDbg.Snoop.CollectorExts.DbMisc.Stream(ArrayList data, ResultBuffer resbuf)
   at MgdDbg.Snoop.CollectorExts.DbMisc.CollectEvent(Object sender, CollectorEventArgs e)
   at MgdDbg.Snoop.Collectors.Collector.CollectorExt.Invoke(Object sender, CollectorEventArgs e)
   at MgdDbg.Snoop.Collectors.Collector.FireEvent_CollectExt(Object objToSnoop)
   at MgdDbg.Snoop.Collectors.Objects.Collect(Object obj)
   at MgdDbg.Snoop.Forms.Objects.TreeNodeSelected(Object sender, TreeViewEventArgs e)
   at System.Windows.Forms.TreeView.OnAfterSelect(TreeViewEventArgs e)
   at System.Windows.Forms.TreeView.TvnSelected(NMTREEVIEW* nmtv)
   at System.Windows.Forms.TreeView.WmNotify(Message& m)
   at System.Windows.Forms.TreeView.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)

In this case tmpValue.Value is a boxed integer and it can't be unboxed as long:

> (long)tmpVal.Value
Cannot unbox 'tmpVal.Value' as a 'long'
