### PR TITLE
fix double casting error + missing parenthesis

### DIFF
--- a/Snoop/CollectorExts/DbMisc.cs
+++ b/Snoop/CollectorExts/DbMisc.cs
@@ -451,7 +451,7 @@ namespace MgdDbg.Snoop.CollectorExts
                     data.Add(new Snoop.Data.String(dxfCodeStr, (string)tmpVal.Value));
                 }
                 else if ((typeCode == 5) || (typeCode == 105)) {
-                    dxfCodeStr = string.Format("{0:d}    (handle/string", typeCode);
+                    dxfCodeStr = string.Format("{0:d}    (handle/string)", typeCode);
                     data.Add(new Snoop.Data.String(dxfCodeStr, (string)tmpVal.Value));
                 }
                 else if ((typeCode >= 10) && (typeCode <= 17)) {
@@ -473,7 +473,7 @@ namespace MgdDbg.Snoop.CollectorExts
                 }
                 else if ((typeCode > 90) && (typeCode <= 99)) {
                     dxfCodeStr = string.Format("{0:d}    (long)", typeCode);
-                    data.Add(new Snoop.Data.Int(dxfCodeStr, (int)(long)tmpVal.Value));
+                    data.Add(new Snoop.Data.Int(dxfCodeStr, (int)tmpVal.Value));
                 }
                 else if (typeCode == 100) {
                     dxfCodeStr = string.Format("{0:d}    (sub-class marker/string)", typeCode);


### PR DESCRIPTION
a while ago I got a fatal crash because of these double casts.

according to the DXF specification, codes 91-99 are 32-bit integers, so `Snoop.Data.Int` should make sense. I'm just not sure why the string says "(long)" on line 475.

If that needs to be adjusted too, let me know

+ also added a missing parenthesis