### PR TITLE
Civil 3D Profile Exception catch.

### DIFF
--- a/ObjTests/QueryCurveTests.cs
+++ b/ObjTests/QueryCurveTests.cs
@@ -908,7 +908,8 @@ namespace MgdDbg.Test
                         Utils.SymTbl.AddToCurrentSpace(newSpline, m_db, tr);
                     }
                     catch (Autodesk.AutoCAD.Runtime.Exception e) {
-                        if (e.ErrorStatus == Autodesk.AutoCAD.Runtime.ErrorStatus.NotApplicable) 
+                        if (e.ErrorStatus == Autodesk.AutoCAD.Runtime.ErrorStatus.NotApplicable ||
+                            e.ErrorStatus == Autodesk.AutoCAD.Runtime.ErrorStatus.NotImplementedYet)
                             m_ed.WriteMessage("\nSPLINE: Not Applicable");
                         else
                             throw;


### PR DESCRIPTION
The Civil 3D Profile class throws an exception of "NotImplementedYet" instead of the expected "NotApplicable". By adding this check, the dialog box will be populated with values instead of being blank. 